### PR TITLE
Deprecation Warning: faker.random.number is now located in faker.data…

### DIFF
--- a/lab01/createTestData.js
+++ b/lab01/createTestData.js
@@ -12,7 +12,7 @@ async function createTestData(recordCount) {
   var f = fs.createWriteStream(fileName);
   f.write('id,name,email,phone\n')
   for (let i=0; i<recordCount; i++) {
-    const id = faker.random.number();
+    const id = faker.datatype.number();
     const firstName = faker.name.firstName();
     const lastName = faker.name.lastName();
     const name = `${firstName} ${lastName}`;


### PR DESCRIPTION
…type.number

Running the script to generate random records floods the console output with the deprecation warning.

Deprecation Warning: faker.random.number is now located in faker.datatype.number

Updating line 15 accordingly resolve the issue.