### PR TITLE
Use GET method instead of POST to display billing to the frontend service

### DIFF
--- a/lab07/prod-api-billing/index.js
+++ b/lab07/prod-api-billing/index.js
@@ -12,7 +12,7 @@ app.listen(port, () => {
   console.log(`Billing Rest API listening on port ${port}`);
 });
 
-app.post('/', async (req, res) => {
+app.get('/', async (req, res) => {
   try {
     bills = await dataSource.listBilling();
 

--- a/lab07/prod-frontend-billing/index.js
+++ b/lab07/prod-frontend-billing/index.js
@@ -32,8 +32,7 @@ app.get('', (req, res) => {
 
 app.post('/', async (req, res) => {
   try {
-    const markdown = 'Test'	  
-    const response = await renderRequest(markdown);
+    const response = await renderRequest();
     res.status(200).send(response);
   } catch (error) {
     console.log(`Error post render function`);	  

--- a/lab07/prod-frontend-billing/render.js
+++ b/lab07/prod-frontend-billing/render.js
@@ -22,19 +22,18 @@ let client, serviceUrl;
 
 // renderRequest creates a new HTTP request with IAM ID Token credential.
 // This token is automatically handled by private Cloud Run (fully managed) and Cloud Functions.
-const renderRequest = async (markdown) => { 
+const renderRequest = async () => {
   if (!process.env.BILLING_URL) throw Error('BILLING_URL needs to be set.');
   
   serviceUrl = process.env.BILLING_URL;
 //  serviceUrl = 'https://billing-prod-service-4qefqezdta-uc.a.run.app'
 
   // Build the request to the Renderer receiving service.
-  const serviceRequestOptions = { 
-    method: 'POST',
+  const serviceRequestOptions = {
+    method: 'GET',
     headers: {
       'Content-Type': 'text/plain'
     },
-    body: markdown,
     timeout: 3000
   };
 


### PR DESCRIPTION
I completed the following lab but there are some bugs that doesn't allow the frontend service to display billing from billing API.
[Serverless Cloud Run Development: Challenge Lab](https://www.cloudskillsboost.google/focuses/14744?parent=catalog&qlcampaign=1s-toronto-0686)

**- Bugs in lab instruction:**
There is a misunderstand between private billing service and prod billing service.

In **Task 5: Deploy the Billing Service**, we're deploying a prod service from `pet-theory/lab07/prod-api-billing`, so the `PROD_BILLING_URL` should be the prod service URL, not private one. So the private billing service is redundant and can be removed from the system

So, this should be changed:
```
Note: Replace PRIVATE_BILLING_SERVICE inside the code-block with Private billing service
PROD_BILLING_URL=$(gcloud run services \
describe PRIVATE_BILLING_SERVICE \
--platform managed \
--region us-central1 \
--format "value(status.url)")
```
to
```
Note: Replace PROD_BILLING_SERVICE inside the code-block with Prod billing service
PROD_BILLING_URL=$(gcloud run services \
describe PROD_BILLING_SERVICE \
--platform managed \
--region us-central1 \
--format "value(status.url)")
```

**- Bug in code:**
To be able to display the billing table as the final screenshot in **Task 7: Redeploy the Frontend Service**, we need to use GET method instead of POST.
This PR is going to fix this bug.

Without these changes, all the lab checkmarks are still green though. But it causes confusion for learners and doesn't bring up the correct lab objectives