### PR TITLE
modifying solution in lab03 Dockerfile

### DIFF
--- a/lab03/solution/Dockerfile
+++ b/lab03/solution/Dockerfile
@@ -1,7 +1,10 @@
-FROM node:12
-RUN apt-get update -y \
-    && apt-get install -y libreoffice \
-    && apt-get clean
+FROM node:12-buster
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libreoffice \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /usr/src/app
 COPY package.json package*.json ./
 RUN npm install --only=production


### PR DESCRIPTION
with the previous docker file getting the above error as the package repositories for Debian Stretch are no longer available. Debian Stretch reached its end of life in July 2020, and its repositories have been moved to archive servers.