### PR TITLE
Add: Migration from URL Redirect to Popup

### DIFF
--- a/lab02/public/index.html
+++ b/lab02/public/index.html
@@ -21,6 +21,8 @@
           }
         },
         signInSuccessUrl: 'customer.html',
+        // https://firebase.google.com/docs/auth/web/redirect-best-practices?hl=en&authuser=0&_gl=1*qtvb1r*_ga*ODMxMTQ5NDI2LjE3MjEwMjgxMDg.*_ga_CW55HF8NVT*MTcyMTAyODEwOC4xLjEuMTcyMTAzMDUxMC42MC4wLjA.
+        signInFlow: 'popup', // Enforce popup authentication
         signInOptions: [
           firebase.auth.GoogleAuthProvider.PROVIDER_ID,
           firebase.auth.FacebookAuthProvider.PROVIDER_ID,

--- a/lab02/solution/public/index.html
+++ b/lab02/solution/public/index.html
@@ -21,6 +21,8 @@
           }
         },
         signInSuccessUrl: 'customer.html',
+        // https://firebase.google.com/docs/auth/web/redirect-best-practices?hl=en&authuser=0&_gl=1*qtvb1r*_ga*ODMxMTQ5NDI2LjE3MjEwMjgxMDg.*_ga_CW55HF8NVT*MTcyMTAyODEwOC4xLjEuMTcyMTAzMDUxMC42MC4wLjA.
+        signInFlow: 'popup', // Enforce popup authentication
         signInOptions: [
           firebase.auth.GoogleAuthProvider.PROVIDER_ID,
           firebase.auth.FacebookAuthProvider.PROVIDER_ID,


### PR DESCRIPTION
General update per Firebase Best practice:

Ref: https://firebase.google.com/docs/auth/web/redirect-best-practices

Migrate from URL Redirect to Popup. Ensure compatibility with new method for authentication, which no longer supports redirects.

