### PR TITLE
Fix for broken got library usage

### DIFF
--- a/lab07/prod-frontend-billing/package.json
+++ b/lab07/prod-frontend-billing/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "google-auth-library": "^9.6.3",
-    "got": "^14.2.0",
+    "got": "^14.4.8",
     "hbs": "^4.2.0",
     "path": "^0.12.7",
     "request": "^2.88.2",

--- a/lab07/prod-frontend-billing/render.js
+++ b/lab07/prod-frontend-billing/render.js
@@ -15,7 +15,7 @@
 // [START run_secure_request]
 
 const {GoogleAuth} = require('google-auth-library');
-const got = import('got');
+const {got} = require('got');
 const auth = new GoogleAuth();
 
 let client, serviceUrl;
@@ -34,8 +34,7 @@ const renderRequest = async (markdown) => {
     headers: {
       'Content-Type': 'text/plain'
     },
-    body: markdown,
-    timeout: 3000
+    body: markdown
   };
 
   try {


### PR DESCRIPTION
In existing code the usage of got fails as the import of the got module seems to conflict with NodeJS's ESM import mechanism. Error message is that got is not a function.

Updates to NodeJS ESM module import support now allow imports of ESM modules using require syntax. Reverting to this syntax and  upgrading got version corrects the above issue in lab.